### PR TITLE
Fixed the bug that the tab id is not opening in microsoft edge

### DIFF
--- a/scripts/open_browser.sh
+++ b/scripts/open_browser.sh
@@ -38,7 +38,7 @@ if echo "$bt_list" | grep -q "$tab_id_name$"; then
 fi
 
 # TODO: pin the tab
-eval "$(tmux_option "@new_browser_window" "screen -dm -- firefox --new-window")" $tab_id_name
+eval "$(tmux_option "@new_browser_window" "screen -dm -- firefox --new-window")" "http://$tab_id_name"
 window_id=$(timeout $TIMEOUT "$CURRENT_DIR/wait_for_new_window.sh" $tab_id_name)
 
 if [ -z "$window_id" ]; then


### PR DESCRIPTION
It should also fix it in chromium because Microsoft Edge is a fork of chromium