### PR TITLE
Added a helper function that logs errors 

### DIFF
--- a/scripts/bt_list_wrapper.sh
+++ b/scripts/bt_list_wrapper.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 TIMEOUT="$(tmux_option "@browser_brotab_timeout" "5.0")"
 bt_list=$(timeout $TIMEOUT bt list)
 
 if [ $? != 0 ]; then
-  # TODO: to avoid this we need to keepalive the mediator from the extension side
-
-  log_error \
-    "[ERROR] Multiple windows with same tab id: $tab_id_name."
-  exit 1
+	# TODO: to avoid this we need to keepalive the mediator from the extension side
+	log_error \
+		"[ERROR] Multiple windows with same tab id: $tab_id_name."
+	exit 1
 fi
 
 echo "$bt_list"

--- a/scripts/bt_list_wrapper.sh
+++ b/scripts/bt_list_wrapper.sh
@@ -10,9 +10,7 @@ if [ $? != 0 ]; then
   # TODO: to avoid this we need to keepalive the mediator from the extension side
 
   log_error \
-    "[ERROR] Multiple windows with same tab id: $tab_id_name. See logs." \
-    "TODO: add something more descriptive here."
-
+    "[ERROR] Multiple windows with same tab id: $tab_id_name."
   exit 1
 fi
 

--- a/scripts/bt_list_wrapper.sh
+++ b/scripts/bt_list_wrapper.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/helpers.sh"
 
 TIMEOUT="$(tmux_option "@browser_brotab_timeout" "5.0")"
 bt_list=$(timeout $TIMEOUT bt list)
 
 if [ $? != 0 ]; then
-	# TODO: to avoid this we need to keepalive the mediator from the extension side
-	tmux display "[CRITICAL ERROR] bt crashed! restart your browser! tmux-browser cant save your sessions!"
-	exit 1
+  # TODO: to avoid this we need to keepalive the mediator from the extension side
+
+  log_error \
+    "[ERROR] Multiple windows with same tab id: $tab_id_name. See logs." \
+    "TODO: add something more descriptive here."
+
+  exit 1
 fi
 
 echo "$bt_list"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,18 +1,37 @@
 #!/usr/bin/env bash
 
-tmux_option()
-{
-	local option="$1"
-	local default_value="$2"
-	local option_value=$(tmux show-option -gqv "$option")
-	if [ -z "$option_value" ]; then
-		echo "$default_value"
-	else
-		echo "$option_value"
-	fi
+tmux_option() {
+  local option="$1"
+  local default_value="$2"
+  local option_value=$(tmux show-option -gqv "$option")
+  if [ -z "$option_value" ]; then
+    echo "$default_value"
+  else
+    echo "$option_value"
+  fi
 }
 
-sessions_dir()
-{
-	echo "$(tmux_option "@browser_session_dir" "$HOME/.tmux/browser-sessions")"
+sessions_dir() {
+  echo "$(tmux_option "@browser_session_dir" "$HOME/.tmux/browser-sessions")"
+}
+
+log_error() {
+  local error_msg="$1"
+  local error_description="$2"
+
+  local LOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../logs"
+  mkdir -p "$LOG_DIR"
+  local timestamp
+  timestamp=$(date +'%c')
+
+  local indented_description
+  indented_description=$(echo "$error_description" | sed 's/^/\t/')
+
+  {
+    echo "[$timestamp] $error_msg"
+    echo -e "$indented_description"
+    echo ""
+  } >>"$LOG_DIR/error_log.txt"
+
+  tmux display "$error_msg"
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,37 +1,39 @@
 #!/usr/bin/env bash
 
-tmux_option() {
-  local option="$1"
-  local default_value="$2"
-  local option_value=$(tmux show-option -gqv "$option")
-  if [ -z "$option_value" ]; then
-    echo "$default_value"
-  else
-    echo "$option_value"
-  fi
+tmux_option()
+{
+	local option="$1"
+	local default_value="$2"
+	local option_value=$(tmux show-option -gqv "$option")
+	if [ -z "$option_value" ]; then
+		echo "$default_value"
+	else
+		echo "$option_value"
+	fi
 }
 
-sessions_dir() {
-  echo "$(tmux_option "@browser_session_dir" "$HOME/.tmux/browser-sessions")"
+sessions_dir()
+{
+	echo "$(tmux_option "@browser_session_dir" "$HOME/.tmux/browser-sessions")"
 }
 
 log_error() {
-  local error_msg="$1"
-  local error_description="$2"
+	local error_msg="$1"
+	local error_description="$2"
 
-  local LOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../logs"
-  mkdir -p "$LOG_DIR"
-  local timestamp
-  timestamp=$(date +'%c')
+	local LOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../logs"
+	mkdir -p "$LOG_DIR"
+	local timestamp
+	timestamp=$(date +'%c')
 
-  local indented_description
-  indented_description=$(echo "$error_description" | sed 's/^/\t/')
+	local indented_description
+	indented_description=$(echo "$error_description" | sed 's/^/\t/')
 
-  {
-    echo "[$timestamp] $error_msg"
-    echo -e "$indented_description"
-    echo ""
-  } >>"$LOG_DIR/error_log.txt"
+	{
+		echo "[$timestamp] $error_msg"
+		echo -e "$indented_description"
+		echo ""
+	} >>"$LOG_DIR/error_log.txt"
 
-  tmux display "$error_msg"
+	tmux display "$error_msg"
 }

--- a/scripts/open_browser.sh
+++ b/scripts/open_browser.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/helpers.sh"
 
 SESSIONS_DIR="$(sessions_dir)"
@@ -10,31 +10,30 @@ current_session=$(tmux display-message -p '#S')
 # Using localhost to don't query any web browser
 tab_id_name=localhost:1212/dont_close-tmux-browser_$current_session
 
-focus_tabid_window()
-{
-	if ! command -v wmctrl &> /dev/null
-	then
-		return
-	fi
+focus_tabid_window() {
+  if ! command -v wmctrl &>/dev/null; then
+    return
+  fi
 
-	window_id=$1
-	active_window_title=$(bt query +active -windowId $window_id | cut -f2)
-	wmctlr_window_id=$(timeout $TIMEOUT "$CURRENT_DIR/wait_for_active_window.sh" $active_window_title)
-	if [ -z "$wmctlr_window_id" ]; then
-		tmux display "[ERROR] Active window not found, not jumping."
-		exit 0
-	fi
-	wmctrl -i -R $wmctlr_window_id
+  window_id=$1
+  active_window_title=$(bt query +active -windowId $window_id | cut -f2)
+  wmctlr_window_id=$(timeout $TIMEOUT "$CURRENT_DIR/wait_for_active_window.sh" $active_window_title)
+  if [ -z "$wmctlr_window_id" ]; then
+    log_error \
+      "[ERROR] Active window not found, not jumping."
+    exit 0
+  fi
+  wmctrl -i -R $wmctlr_window_id
 }
 
 tmux display "[INFO] tmux-browser: Opening Browser!"
 bt_list=$($CURRENT_DIR/bt_list_wrapper.sh) || exit $?
 
 if echo "$bt_list" | grep -q "$tab_id_name$"; then
-	tmux display "[INFO] Session is already running!"
-	window_id=$(echo "$bt_list" | cut -f1,3 | grep "$tab_id_name$" | cut -f2 -d ".")
-	focus_tabid_window $window_id
-	exit 0
+  tmux display "[INFO] Session is already running!"
+  window_id=$(echo "$bt_list" | cut -f1,3 | grep "$tab_id_name$" | cut -f2 -d ".")
+  focus_tabid_window $window_id
+  exit 0
 fi
 
 # TODO: pin the tab
@@ -43,21 +42,24 @@ tmux run-shell -b "$open_browser_command"
 window_id=$(timeout $TIMEOUT "$CURRENT_DIR/wait_for_new_window.sh" $tab_id_name)
 
 if [ -z "$window_id" ]; then
-	tmux display "[ERROR] Web browser window was not found"
-	exit 0
+  log_error \
+    "[ERROR] Web browser window was not found"
+
+  exit 0
 fi
 
 if [[ $(echo $window_id | tr -cd ' \t' | wc -c) != '0' ]]; then
-	tmux display "[ERROR] Multiple windows with the same tab id name: $tab_id_name"
-	exit 0
+  log_error \
+    "[ERROR] Multiple windows with the same tab id name: $tab_id_name"
+  exit 0
 fi
 
 if [ -f "$SESSIONS_DIR/$current_session" ]; then
-	tmux display "Restoring from $SESSIONS_DIR/$current_session"
-	# Only opening http/s urls (about:new make bt stuck)
-	cat "$SESSIONS_DIR/$current_session" | grep "^http" | bt open $window_id &> /dev/null
+  tmux display "Restoring from $SESSIONS_DIR/$current_session"
+  # Only opening http/s urls (about:new make bt stuck)
+  cat "$SESSIONS_DIR/$current_session" | grep "^http" | bt open $window_id &>/dev/null
 else
-	tmux display "New Browser Opened"
+  tmux display "New Browser Opened"
 fi
 
 window_id=$(echo $window_id | cut -f2 -d ".")

--- a/scripts/open_browser.sh
+++ b/scripts/open_browser.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 SESSIONS_DIR="$(sessions_dir)"
@@ -10,30 +10,32 @@ current_session=$(tmux display-message -p '#S')
 # Using localhost to don't query any web browser
 tab_id_name=localhost:1212/dont_close-tmux-browser_$current_session
 
-focus_tabid_window() {
-  if ! command -v wmctrl &>/dev/null; then
-    return
-  fi
+focus_tabid_window()
+{
+	if ! command -v wmctrl &> /dev/null
+	then
+		return
+	fi
 
-  window_id=$1
-  active_window_title=$(bt query +active -windowId $window_id | cut -f2)
-  wmctlr_window_id=$(timeout $TIMEOUT "$CURRENT_DIR/wait_for_active_window.sh" $active_window_title)
-  if [ -z "$wmctlr_window_id" ]; then
-    log_error \
-      "[ERROR] Active window not found, not jumping."
-    exit 0
-  fi
-  wmctrl -i -R $wmctlr_window_id
+	window_id=$1
+	active_window_title=$(bt query +active -windowId $window_id | cut -f2)
+	wmctlr_window_id=$(timeout $TIMEOUT "$CURRENT_DIR/wait_for_active_window.sh" $active_window_title)
+	if [ -z "$wmctlr_window_id" ]; then
+		log_error \
+			"[ERROR] Active window not found, not jumping."
+		exit 0
+	fi
+	wmctrl -i -R $wmctlr_window_id
 }
 
 tmux display "[INFO] tmux-browser: Opening Browser!"
 bt_list=$($CURRENT_DIR/bt_list_wrapper.sh) || exit $?
 
 if echo "$bt_list" | grep -q "$tab_id_name$"; then
-  tmux display "[INFO] Session is already running!"
-  window_id=$(echo "$bt_list" | cut -f1,3 | grep "$tab_id_name$" | cut -f2 -d ".")
-  focus_tabid_window $window_id
-  exit 0
+	tmux display "[INFO] Session is already running!"
+	window_id=$(echo "$bt_list" | cut -f1,3 | grep "$tab_id_name$" | cut -f2 -d ".")
+	focus_tabid_window $window_id
+	exit 0
 fi
 
 # TODO: pin the tab
@@ -42,24 +44,23 @@ tmux run-shell -b "$open_browser_command"
 window_id=$(timeout $TIMEOUT "$CURRENT_DIR/wait_for_new_window.sh" $tab_id_name)
 
 if [ -z "$window_id" ]; then
-  log_error \
-    "[ERROR] Web browser window was not found"
-
-  exit 0
+	log_error \
+		"[ERROR] Web browser window was not found"
+	exit 0
 fi
 
 if [[ $(echo $window_id | tr -cd ' \t' | wc -c) != '0' ]]; then
-  log_error \
-    "[ERROR] Multiple windows with the same tab id name: $tab_id_name"
-  exit 0
+	log_error \
+		"[ERROR] Multiple windows with the same tab id name: $tab_id_name"
+	exit 0
 fi
 
 if [ -f "$SESSIONS_DIR/$current_session" ]; then
-  tmux display "Restoring from $SESSIONS_DIR/$current_session"
-  # Only opening http/s urls (about:new make bt stuck)
-  cat "$SESSIONS_DIR/$current_session" | grep "^http" | bt open $window_id &>/dev/null
+	tmux display "Restoring from $SESSIONS_DIR/$current_session"
+	# Only opening http/s urls (about:new make bt stuck)
+	cat "$SESSIONS_DIR/$current_session" | grep "^http" | bt open $window_id &> /dev/null
 else
-  tmux display "New Browser Opened"
+	tmux display "New Browser Opened"
 fi
 
 window_id=$(echo $window_id | cut -f2 -d ".")


### PR DESCRIPTION
The helper function displays the error message on tmux like normal, but it will also log the message with a timestamp to a txt file. The helper function can be passed with 1 or 2 arguments - the first will be sent to tmux and the log file, and the second (optional) parameter gets sent to the log file, exclusively, with additional information about the error message. 

Example:

```bash
log_error \
  "[ERROR] Multiple windows with same tab id: $tab_id_name. See logs." \                   
  "Bla bla bla additional information about the error"
```
