### PR TITLE
Fix shebang paths for NixOS compatibility

### DIFF
--- a/scripts/bt_list_wrapper.sh
+++ b/scripts/bt_list_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"

--- a/scripts/save_session.sh
+++ b/scripts/save_session.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"

--- a/scripts/save_sessions.sh
+++ b/scripts/save_sessions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"


### PR DESCRIPTION
To ensure that the scripts work properly on NixOS, I had to fix the shebang paths. Specifically, I updated the shebang to #!/usr/bin/env bash so it correctly resolves the bash interpreter in the environment